### PR TITLE
relock m_mutex after get_data_from_selection_owner()

### DIFF
--- a/clip_x11.cpp
+++ b/clip_x11.cpp
@@ -585,14 +585,15 @@ private:
                               event->property,
                               m_target_atom);
     if (reply) {
+      xcb_atom_t reply_type = reply->type;
       // In this case, We're going to receive the clipboard content in
       // chunks of data with several PropertyNotify events.
-      if (reply->type == get_atom(INCR)) {
+      if (reply_type == get_atom(INCR)) {
         free(reply);
 
         reply = get_and_delete_property(event->requestor,
                                         event->property,
-                                        reply->type);
+                                        reply_type);
         if (reply) {
           if (xcb_get_property_value_length(reply) == 4) {
             uint32_t n = *(uint32_t*)xcb_get_property_value(reply);

--- a/clip_x11.cpp
+++ b/clip_x11.cpp
@@ -741,6 +741,7 @@ private:
         if (status == std::cv_status::no_timeout) {
           // If the condition variable was notified, it means that the
           // callback was called correctly.
+          lock.release();
           return m_callback_result;
         }
       } while (m_incr_received);
@@ -748,6 +749,7 @@ private:
 
     // Reset callback
     m_callback = notify_callback();
+    lock.release();
     return false;
   }
 


### PR DESCRIPTION
When get_data_from_selection_owner() returns, m_mutex
is unlocked in the destructor of std::unique_lock.
Ensure that the current thread re-acquires the mutex
before continuing after calling this function.

Found when trying to run this code on OpenBSD, which calls
abort() in pthread_mutex_unlock() with an unlocked mutex.