### PR TITLE
Call SHCreateMemStream by ordinal for Windows XP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ endif()
 add_library(clip ${CLIP_SOURCES})
 
 if(WIN32)
+  option(CLIP_SUPPORT_WINXP "Enable Windows XP support" OFF)
+  if (CLIP_SUPPORT_WINXP)
+    add_definitions(-DCLIP_SUPPORT_WINXP)
+  endif()
   target_link_libraries(clip shlwapi)
 
   # MinGW requires the windowscodecs just because CLSIDs are defined

--- a/clip_win_wic.h
+++ b/clip_win_wic.h
@@ -15,6 +15,15 @@
 namespace clip {
 namespace win {
 
+// Pull SHCreateMemStream from shlwapi.dll by ordinal 12
+// for Windows XP support
+// From: https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shcreatememstream#remarks
+
+typedef IStream* (WINAPI *SHCreateMemStreamPtr)(const BYTE *pInit, UINT cbInit);
+HMODULE shlwapiDLL = LoadLibraryW(L"shlwapi.dll");
+FARPROC pSHCreateMemStreamOrdinal = GetProcAddress(shlwapiDLL, (LPCSTR)12);
+SHCreateMemStreamPtr SHCreateMemStream = (SHCreateMemStreamPtr)pSHCreateMemStreamOrdinal;
+
 // Successful calls to CoInitialize() (S_OK or S_FALSE) must match
 // the calls to CoUninitialize().
 // From: https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-couninitialize#remarks

--- a/clip_win_wic.h
+++ b/clip_win_wic.h
@@ -179,6 +179,11 @@ bool read_png(const uint8_t* buf,
 #endif
 
   comptr<IStream> stream(SHCreateMemStream(buf, len));
+  
+#ifdef CLIP_SUPPORT_WINXP
+  FreeLibrary(shlwapiDLL);
+#endif
+
   if (!stream)
     return false;
 

--- a/clip_win_wic.h
+++ b/clip_win_wic.h
@@ -15,15 +15,6 @@
 namespace clip {
 namespace win {
 
-// Pull SHCreateMemStream from shlwapi.dll by ordinal 12
-// for Windows XP support
-// From: https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shcreatememstream#remarks
-
-typedef IStream* (WINAPI *SHCreateMemStreamPtr)(const BYTE *pInit, UINT cbInit);
-HMODULE shlwapiDLL = LoadLibraryW(L"shlwapi.dll");
-FARPROC pSHCreateMemStreamOrdinal = GetProcAddress(shlwapiDLL, (LPCSTR)12);
-SHCreateMemStreamPtr SHCreateMemStream = (SHCreateMemStreamPtr)pSHCreateMemStreamOrdinal;
-
 // Successful calls to CoInitialize() (S_OK or S_FALSE) must match
 // the calls to CoUninitialize().
 // From: https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-couninitialize#remarks
@@ -175,6 +166,17 @@ bool read_png(const uint8_t* buf,
               image* output_image,
               image_spec* output_spec) {
   coinit com;
+
+#ifdef CLIP_SUPPORT_WINXP
+  // Pull SHCreateMemStream from shlwapi.dll by ordinal 12
+  // for Windows XP support
+  // From: https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shcreatememstream#remarks
+  
+  typedef IStream* (WINAPI *SHCreateMemStreamPtr)(const BYTE *pInit, UINT cbInit);
+  HMODULE shlwapiDLL = LoadLibraryW(L"shlwapi.dll");
+  FARPROC pSHCreateMemStreamOrdinal = GetProcAddress(shlwapiDLL, (LPCSTR)12);
+  SHCreateMemStreamPtr SHCreateMemStream = (SHCreateMemStreamPtr)pSHCreateMemStreamOrdinal;
+#endif
 
   comptr<IStream> stream(SHCreateMemStream(buf, len));
   if (!stream)


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- If you're a first-time contributor, please acknowledge it by
     leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT

Prior to Vista, SHCreateMemStream was available in Windows XP, but needed to be called by ordinal 12, rather than by name. Doing this doesn't affect functionality in higher versions of windows. Tested with MinGW on 32-bit Windows XP and Windows 11 x64.
