### PR TITLE
[osx] Make get_image_from_clipboard() function public

### DIFF
--- a/clip_osx.h
+++ b/clip_osx.h
@@ -1,0 +1,35 @@
+// Clip Library
+// Copyright (c) 2024 David Capello
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifndef CLIP_OSX_H_INCLUDED
+#define CLIP_OSX_H_INCLUDED
+#pragma once
+
+#ifdef __OBJC__
+
+#include <Cocoa/Cocoa.h>
+
+namespace clip {
+
+class image;
+struct image_spec;
+
+namespace osx {
+
+#if CLIP_ENABLE_IMAGE
+
+bool get_image_from_clipboard(NSPasteboard* pasteboard,
+                              image* output_img,
+                              image_spec* output_spec);
+
+#endif // CLIP_ENABLE_IMAGE
+
+} // namespace osx
+} // namespace clip
+
+#endif
+
+#endif

--- a/clip_osx.mm
+++ b/clip_osx.mm
@@ -24,12 +24,16 @@ namespace {
   std::map<std::string, format> g_name_to_format;
   std::map<format, std::string> g_format_to_name;
 
+}
+
+namespace osx {
+
 #if CLIP_ENABLE_IMAGE
 
-  bool get_image_from_clipboard(image* output_img,
+  bool get_image_from_clipboard(NSPasteboard* pasteboard,
+                                image* output_img,
                                 image_spec* output_spec)
   {
-    NSPasteboard* pasteboard = [NSPasteboard generalPasteboard];
     NSString* result = [pasteboard availableTypeFromArray:
                                 [NSArray arrayWithObjects:NSPasteboardTypeTIFF,NSPasteboardTypePNG,nil]];
 
@@ -347,11 +351,11 @@ bool lock::impl::set_image(const image& image) {
 }
 
 bool lock::impl::get_image(image& img) const {
-  return get_image_from_clipboard(&img, nullptr);
+  return osx::get_image_from_clipboard([NSPasteboard generalPasteboard], &img, nullptr);
 }
 
 bool lock::impl::get_image_spec(image_spec& spec) const {
-  return get_image_from_clipboard(nullptr, &spec);
+  return osx::get_image_from_clipboard([NSPasteboard generalPasteboard], nullptr, &spec);
 }
 
 #endif // CLIP_ENABLE_IMAGE


### PR DESCRIPTION
This function might be useful for third-party libraries (like laf, aseprite/laf#83) to implement a drag-and-drop functionality.
