### PR TITLE
Impersonate anonymous token when closing Clipboard, resolves #71

### DIFF
--- a/clip_win.cpp
+++ b/clip_win.cpp
@@ -55,14 +55,16 @@ private:
 
 class AnonymousTokenImpersonator {
 public:
-	AnonymousTokenImpersonator()
-	    : must_revert(::ImpersonateAnonymousToken(::GetCurrentThread())) {
-	}
-	~AnonymousTokenImpersonator() {
-		if (must_revert) ::RevertToSelf();
-	}
+  AnonymousTokenImpersonator()
+    : must_revert(ImpersonateAnonymousToken(GetCurrentThread()))
+  {}
+
+  ~AnonymousTokenImpersonator() {
+    if (must_revert)
+      RevertToSelf();
+  }
 private:
-	const bool must_revert;
+  const bool must_revert;
 };
 
 }

--- a/clip_win.cpp
+++ b/clip_win.cpp
@@ -53,6 +53,18 @@ private:
   HGLOBAL m_handle;
 };
 
+class AnonymousTokenImpersonator {
+public:
+	AnonymousTokenImpersonator()
+	    : must_revert(::ImpersonateAnonymousToken(::GetCurrentThread())) {
+	}
+	~AnonymousTokenImpersonator() {
+		if (must_revert) ::RevertToSelf();
+	}
+private:
+	const bool must_revert;
+};
+
 }
 
 lock::impl::impl(void* hwnd) : m_locked(false) {
@@ -72,8 +84,10 @@ lock::impl::impl(void* hwnd) : m_locked(false) {
 }
 
 lock::impl::~impl() {
-  if (m_locked)
+  if (m_locked) {
+    AnonymousTokenImpersonator guard{};
     CloseClipboard();
+  }
 }
 
 bool lock::impl::clear() {


### PR DESCRIPTION
This commit introduces the `AnonymousTokenImpersonator` class which acts as a scope guard under which `CloseClipboard` is called. 

Resolves issue #71

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- If you're a first-time contributor, please acknowledge it by
     leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
