### PR TITLE
Add support to decode JPEG, GIF and BMP formats, and more pixel formats

### DIFF
--- a/clip_win_wic.cpp
+++ b/clip_win_wic.cpp
@@ -178,51 +178,97 @@ HGLOBAL write_png(const image& image) {
   return nullptr;
 }
 
-//////////////////////////////////////////////////////////////////////
-// Decode the clipboard data from PNG format
-
-bool read_png(const uint8_t* buf,
-              const UINT len,
-              image* output_image,
-              image_spec* output_spec) {
-  coinit com;
-
+IStream* create_stream(const BYTE* pInit, UINT cbInit)
+{
 #ifdef CLIP_SUPPORT_WINXP
   // Pull SHCreateMemStream from shlwapi.dll by ordinal 12
   // for Windows XP support
   // From: https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shcreatememstream#remarks
 
-  typedef IStream* (WINAPI* SHCreateMemStreamPtr)(const BYTE* pInit, UINT cbInit);
+  typedef IStream*(WINAPI * SHCreateMemStreamPtr)(const BYTE* pInit,
+                                                  UINT cbInit);
   hmodule shlwapiDll(L"shlwapi.dll");
   if (!shlwapiDll)
     return false;
 
-  auto SHCreateMemStream =
-    reinterpret_cast<SHCreateMemStreamPtr>(GetProcAddress(shlwapiDll, (LPCSTR)12));
+  auto SHCreateMemStream = reinterpret_cast<SHCreateMemStreamPtr>(
+    GetProcAddress(shlwapiDll, (LPCSTR)12));
   if (!SHCreateMemStream)
     return false;
 #endif
+  return SHCreateMemStream(pInit, cbInit);
+}
 
-  comptr<IStream> stream(SHCreateMemStream(buf, len));
+image_spec spec_from_pixelformat(const WICPixelFormatGUID& pixelFormat, unsigned long w, unsigned long h)
+{
+  image_spec spec;
+  spec.width = w;
+  spec.height = h;
+  if (pixelFormat == GUID_WICPixelFormat32bppBGRA ||
+      pixelFormat == GUID_WICPixelFormat32bppBGR) {
+    spec.bits_per_pixel = 32;
+    spec.red_mask = 0xff0000;
+    spec.green_mask = 0xff00;
+    spec.blue_mask = 0xff;
+    spec.alpha_mask = 0xff000000;
+    spec.red_shift = 16;
+    spec.green_shift = 8;
+    spec.blue_shift = 0;
+    spec.alpha_shift = 24;
+  }
+  else if (pixelFormat == GUID_WICPixelFormat24bppBGR ||
+           pixelFormat == GUID_WICPixelFormat8bppIndexed) {
+    spec.bits_per_pixel = 24;
+    spec.red_mask = 0xff0000;
+    spec.green_mask = 0xff00;
+    spec.blue_mask = 0xff;
+    spec.alpha_mask = 0;
+    spec.red_shift = 16;
+    spec.green_shift = 8;
+    spec.blue_shift = 0;
+    spec.alpha_shift = 0;
+  }
+  spec.bytes_per_row = ((w*spec.bits_per_pixel+31) / 32) * 4;
+  return spec;
+}
 
-  if (!stream)
+// Tries to decode the input buf of size len using the first decoder available from the
+// ones specified in decoderCLSIDs vector. If output_image is not null, the decoded
+// image is returned there, if output_spec is not null then the image specifications
+// are set there.
+bool decode(std::vector<GUID> decoderCLSIDs,
+            const uint8_t* buf,
+            const UINT len,
+            image* output_image,
+            image_spec* output_spec)
+{
+  if (decoderCLSIDs.empty())
     return false;
 
+  coinit com;
+
   comptr<IWICBitmapDecoder> decoder;
-  HRESULT hr = CoCreateInstance(CLSID_WICPngDecoder2,
-                                nullptr, CLSCTX_INPROC_SERVER,
-                                IID_PPV_ARGS(&decoder));
-  if (FAILED(hr)) {
-    hr = CoCreateInstance(CLSID_WICPngDecoder1,
-                          nullptr, CLSCTX_INPROC_SERVER,
+
+  HRESULT hr = E_FAIL;
+  for (GUID decoderCLSID : decoderCLSIDs) {
+    hr = CoCreateInstance(decoderCLSID, nullptr,
+                          CLSCTX_INPROC_SERVER,
                           IID_PPV_ARGS(&decoder));
-    if (FAILED(hr))
-      return false;
+    if (SUCCEEDED(hr))
+      break;
   }
+
+  if (FAILED(hr))
+    return false;
 
   // Can decoder be nullptr if hr is S_OK/successful? We've received
   // some crash reports that might indicate this.
   if (!decoder)
+    return false;
+
+  comptr<IStream> stream(create_stream(buf, len));
+
+  if (!stream)
     return false;
 
   hr = decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand);
@@ -239,9 +285,12 @@ bool read_png(const uint8_t* buf,
   if (FAILED(hr))
     return false;
 
-  // Only support this pixel format
+  // Only support these pixel formats
   // TODO add support for more pixel formats
-  if (pixelFormat != GUID_WICPixelFormat32bppBGRA)
+  if (pixelFormat != GUID_WICPixelFormat32bppBGRA &&
+      pixelFormat != GUID_WICPixelFormat32bppBGR &&
+      pixelFormat != GUID_WICPixelFormat24bppBGR &&
+      pixelFormat != GUID_WICPixelFormat8bppIndexed)
     return false;
 
   UINT width = 0, height = 0;
@@ -249,39 +298,126 @@ bool read_png(const uint8_t* buf,
   if (FAILED(hr))
     return false;
 
-  image_spec spec;
-  spec.width = width;
-  spec.height = height;
-  spec.bits_per_pixel = 32;
-  spec.bytes_per_row = 4 * width;
-  spec.red_mask    = 0xff0000;
-  spec.green_mask  = 0xff00;
-  spec.blue_mask   = 0xff;
-  spec.alpha_mask  = 0xff000000;
-  spec.red_shift   = 16;
-  spec.green_shift = 8;
-  spec.blue_shift  = 0;
-  spec.alpha_shift = 24;
+  image_spec spec = spec_from_pixelformat(pixelFormat, width, height);
 
   if (output_spec)
     *output_spec = spec;
 
+  image img;
   if (output_image) {
-    image img(spec);
+    if (pixelFormat == GUID_WICPixelFormat8bppIndexed) {
+      std::vector<BYTE> pixels(spec.width * spec.height);
+      hr = frame->CopyPixels(nullptr,  // Entire bitmap
+                             spec.width,
+                             spec.width * spec.height,
+                             pixels.data());
 
-    hr = frame->CopyPixels(
-      nullptr, // Entire bitmap
-      spec.bytes_per_row,
-      spec.bytes_per_row * spec.height,
-      (BYTE*)img.data());
-    if (FAILED(hr)) {
-      return false;
+      if (FAILED(hr))
+        return false;
+
+      comptr<IWICImagingFactory> factory;
+      HRESULT hr = CoCreateInstance(CLSID_WICImagingFactory,
+                                    nullptr,
+                                    CLSCTX_INPROC_SERVER,
+                                    IID_PPV_ARGS(&factory));
+      if (FAILED(hr))
+        return false;
+
+      comptr<IWICPalette> palette;
+      hr = factory->CreatePalette(&palette);
+      if (FAILED(hr))
+        return false;
+
+      hr = frame->CopyPalette(palette.get());
+      if (FAILED(hr))
+        return false;
+
+      UINT numcolors;
+      hr = palette->GetColorCount(&numcolors);
+      if (FAILED(hr))
+        return false;
+
+      UINT actualNumcolors;
+      std::vector<WICColor> colors(numcolors);
+      hr = palette->GetColors(numcolors, colors.data(), &actualNumcolors);
+      if (FAILED(hr))
+        return false;
+
+      BOOL hasAlpha = false;
+      palette->HasAlpha(&hasAlpha);
+      if (hasAlpha) {
+        spec = spec_from_pixelformat(GUID_WICPixelFormat32bppBGRA, width, height);
+      }
+
+      img = image(spec);
+      char* dst = img.data();
+      BYTE* src = pixels.data();
+      for (int y = 0; y < spec.height; ++y) {
+        char* dst_x = dst;
+        for (int x = 0; x < spec.width; ++x, dst_x+=spec.bits_per_pixel/8, ++src) {
+          *((uint32_t*)dst_x) = colors[*src];
+        }
+        dst += spec.bytes_per_row;
+      }
     }
+    else {
+      img = image(spec);
+      hr = frame->CopyPixels(nullptr,  // Entire bitmap
+                             spec.bytes_per_row,
+                             spec.bytes_per_row * spec.height,
+                             (BYTE*)img.data());
+      if (FAILED(hr))
+        return false;
+    }
+
 
     std::swap(*output_image, img);
   }
 
   return true;
+}
+
+//////////////////////////////////////////////////////////////////////
+// Decode the clipboard data from PNG format
+
+bool read_png(const uint8_t* buf,
+              const UINT len,
+              image* output_image,
+              image_spec* output_spec) {
+  return decode({CLSID_WICPngDecoder2, CLSID_WICPngDecoder1}, buf, len, output_image, output_spec);
+}
+
+//////////////////////////////////////////////////////////////////////
+// Decode the clipboard data from JPEG format
+
+bool read_jpg(const uint8_t* buf,
+              const UINT len,
+              image* output_image,
+              image_spec* output_spec)
+{
+  return decode({CLSID_WICJpegDecoder}, buf, len, output_image, output_spec);
+}
+
+//////////////////////////////////////////////////////////////////////
+// Decode the clipboard data from GIF format
+
+bool read_gif(const uint8_t* buf,
+              const UINT len,
+              image* output_image,
+              image_spec* output_spec)
+{
+  return decode({CLSID_WICGifDecoder}, buf, len, output_image, output_spec);
+}
+
+//////////////////////////////////////////////////////////////////////
+// Decode the clipboard data from BMP format
+
+bool read_bmp(const uint8_t* buf,
+              const UINT len,
+              image* output_image,
+              image_spec* output_spec)
+{
+  return decode({ CLSID_WICBmpDecoder }, buf, len, output_image, output_spec);
 }
 
 } // namespace win

--- a/clip_win_wic.cpp
+++ b/clip_win_wic.cpp
@@ -215,6 +215,11 @@ image_spec spec_from_pixelformat(const WICPixelFormatGUID& pixelFormat, unsigned
     spec.green_shift = 8;
     spec.blue_shift = 0;
     spec.alpha_shift = 24;
+    // Reset mask and shift for BGR pixel format.
+    if (pixelFormat == GUID_WICPixelFormat32bppBGR) {
+      spec.alpha_mask = 0;
+      spec.alpha_shift = 0;
+    }
   }
   else if (pixelFormat == GUID_WICPixelFormat24bppBGR ||
            pixelFormat == GUID_WICPixelFormat8bppIndexed) {

--- a/clip_win_wic.cpp
+++ b/clip_win_wic.cpp
@@ -360,7 +360,7 @@ bool decode(std::vector<GUID> decoderCLSIDs,
       for (int y = 0; y < spec.height; ++y) {
         char* dst_x = dst;
         for (int x = 0; x < spec.width; ++x, dst_x+=spec.bits_per_pixel/8, ++src) {
-          *((uint32_t*)dst_x) = colors[*src];
+          *((uint32_t*)dst_x) = (*src < numcolors ? colors[*src] : 0);
         }
         dst += spec.bytes_per_row;
       }

--- a/clip_win_wic.cpp
+++ b/clip_win_wic.cpp
@@ -417,7 +417,7 @@ bool read_bmp(const uint8_t* buf,
               image* output_image,
               image_spec* output_spec)
 {
-  return decode({ CLSID_WICBmpDecoder }, buf, len, output_image, output_spec);
+  return decode({CLSID_WICBmpDecoder}, buf, len, output_image, output_spec);
 }
 
 } // namespace win

--- a/clip_win_wic.h
+++ b/clip_win_wic.h
@@ -23,6 +23,13 @@ struct image_spec;
 
 namespace win {
 
+typedef bool (*ReadWicImageFormatFunc)(const uint8_t*,
+                                       const UINT,
+                                       clip::image*,
+                                       clip::image_spec*);
+
+ReadWicImageFormatFunc wic_image_format_available(UINT* output_cbformat);
+
 //////////////////////////////////////////////////////////////////////
 // Encode the image as PNG format
 

--- a/clip_win_wic.h
+++ b/clip_win_wic.h
@@ -38,6 +38,31 @@ bool read_png(const uint8_t* buf,
               image* output_image,
               image_spec* output_spec);
 
+//////////////////////////////////////////////////////////////////////
+// Decode the clipboard data from JPEG format
+
+bool read_jpg(const uint8_t* buf,
+              const UINT len,
+              image* output_image,
+              image_spec* output_spec);
+
+//////////////////////////////////////////////////////////////////////
+// Decode the clipboard data from GIF format
+
+bool read_gif(const uint8_t* buf,
+              const UINT len,
+              image* output_image,
+              image_spec* output_spec);
+
+//////////////////////////////////////////////////////////////////////
+// Decode the clipboard data from BMP format
+
+bool read_bmp(const uint8_t* buf,
+              const UINT len,
+              image* output_image,
+              image_spec* output_spec);
+
+
 } // namespace win
 } // namespace clip
 


### PR DESCRIPTION
Add support to decode data in JPEG, GIF, or BMP formats. When decoding animated GIFs only the first frame is taken into account.
Also this PR adds support to decoded images in more pixel formats: 24bpp, 32bpp without alpha, and 8bpp indexed with or without alpha.

This changes will be needed for a future commit (which I'm currently working on) in laf to make the drag&drop of images from Chrome on Windows behave in a similar fashion as Chrome on macOS. Because figured out that the dragged data from Chrome contains a CFSTR_FILEDESCRIPTOR and a CFSTR_FILECONTENTS, which means that we can get the content of the file where the image is temporarily stored.