### PR TITLE
fix illegal instruction due to missing return value

### DIFF
--- a/clip_win_bmp.cpp
+++ b/clip_win_bmp.cpp
@@ -84,8 +84,9 @@ bool BitmapInfo::load_from(BITMAPINFO* bi) {
     blue_mask  = *((uint32_t*)&bi->bmiColors[2]);
     if (bit_count == 32)
       alpha_mask = 0xff000000;
+    return true;
   }
-  else if (compression == BI_RGB) {
+  if (compression == BI_RGB) {
     switch (bit_count) {
       case 32:
         red_mask   = 0xff0000;
@@ -105,7 +106,9 @@ bool BitmapInfo::load_from(BITMAPINFO* bi) {
         blue_mask  = 0x001f;
         break;
     }
+    return true;
   }
+  return false;
 }
 
 BitmapInfo::BitmapInfo(BITMAPV5HEADER* pb5) {


### PR DESCRIPTION
I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT

illegal instruction occurred when i pressed print screen and then run show_image example.