### PR TITLE
Add CMake installation rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ if(WIN32)
 endif()
 option(CLIP_EXAMPLES "Compile clip examples" on)
 option(CLIP_TESTS "Compile clip tests" on)
+option(CLIP_INSTALL "Enable clip installation" on)
 if(UNIX AND NOT APPLE)
   option(CLIP_X11_WITH_PNG "Compile with libpng to support copy/paste image in png format" on)
 endif()
@@ -103,4 +104,24 @@ endif()
 if(CLIP_TESTS)
   enable_testing()
   add_subdirectory(tests)
+endif()
+
+if(CLIP_INSTALL)
+  include(GNUInstallDirs)
+
+  install(
+    FILES clip.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+  install(
+    TARGETS clip
+    EXPORT clip-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+  install(
+    EXPORT clip-targets
+    NAMESPACE clip::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/clip
+  )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,4 +124,16 @@ if(CLIP_INSTALL)
     NAMESPACE clip::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/clip
   )
+
+  include(CMakePackageConfigHelpers)
+
+  configure_package_config_file(
+    clip-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/clip-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/clip
+  )
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/clip-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/clip
+  )
 endif()

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ int main() {
   [list_clip_formats](examples/list_clip_formats.cpp) example.
 * `CLIP_EXAMPLES`: Compile [examples](examples/).
 * `CLIP_TESTS`: Compile [tests](tests/).
+* `CLIP_INSTALL`: Generate installation rules for CMake.
 * `CLIP_X11_WITH_PNG` (only for Linux/X11): Enables support to
   copy/paste images using the `libpng` library on Linux.
 

--- a/clip-config.cmake.in
+++ b/clip-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets.cmake")
+check_required_components("@CMAKE_PROJECT_NAME@")


### PR DESCRIPTION
This change adds installation rules for CMake to simplify the library's distribution as a separate project (e.g. making a package).

Resolves #77.

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
