### PR TITLE
Fix missing cstdint includes

### DIFF
--- a/clip_win.cpp
+++ b/clip_win.cpp
@@ -10,6 +10,7 @@
 #include "clip_lock_impl.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <string>

--- a/examples/put_image.cpp
+++ b/examples/put_image.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2016 David Capello
 
 #include "clip.h"
+#include <cstdint>
 #include <iostream>
 
 int main() {

--- a/examples/show_image.cpp
+++ b/examples/show_image.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2015-2016 David Capello
 
 #include "clip.h"
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 

--- a/tests/image_tests.cpp
+++ b/tests/image_tests.cpp
@@ -8,6 +8,7 @@
 
 #include "clip.h"
 
+#include <cstdint>
 #include <cstring>
 
 using namespace clip;


### PR DESCRIPTION
GCC 15 improved its std header isolation and `<cstdint>` now included less transitively.
Include `<cstdint>` where [u]int*_t is used.

I agree that my contributions are licensed under the MIT License.
