### PR TITLE
docs: update copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Clip Library
-*Copyright (c) 2015-2024 David Capello*
+*Copyright (c) 2015-2025 David Capello*
 
 [![build](https://github.com/dacap/clip/workflows/build/badge.svg)](https://github.com/dacap/clip/actions?query=workflow%3Abuild)
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)


### PR DESCRIPTION
## Describe the PR

This PR updates the copyright year from `2024` to `2025` (which is the current year).

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT