### PR TITLE
Add BUILD_INTERFACE include directory to fix header includes when using CPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ endif()
 
 add_library(clip clip.cpp)
 
-target_include_directories(clip INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_include_directories(clip INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> 
+										  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_definitions(clip PRIVATE -DCLIP_BUILDING_LIB=1)
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(clip PUBLIC -DCLIP_SHARED=1)


### PR DESCRIPTION
This change adds the build interface include directory. In my case, when importing the library via CPM, I wasn’t able to include its header files because the build interface include path was not defined, and this fixes that issue.

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
