### PR TITLE
Fixed integer sign comparison warning in clip_osx.mm

### DIFF
--- a/clip_osx.mm
+++ b/clip_osx.mm
@@ -230,7 +230,7 @@ bool lock::impl::get_data(format f, char* buf, size_t len) const {
 
     if (f == text_format()) {
       NSString* string = [pasteboard stringForType:NSPasteboardTypeString];
-      int reqsize = [string lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1;
+      size_t reqsize = [string lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1;
 
       assert(reqsize <= len);
       if (reqsize > len) {


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- If you're a first-time contributor, please acknowledge it by
     leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT

https://github.com/dacap/clip/issues/95
